### PR TITLE
Use USB's binary coded decimal encoding for version numbers.

### DIFF
--- a/index.html
+++ b/index.html
@@ -145,13 +145,13 @@
       <pre class="idl">
         [NoInterfaceObject]
         interface USBDevice {
-          readonly attribute float usbVersion;
+          readonly attribute unsigned short usbVersion;
           readonly attribute octet deviceClass;
           readonly attribute octet deviceSubclass;
           readonly attribute octet deviceProtocol;
           readonly attribute unsigned short vendorId;
           readonly attribute unsigned short productId;
-          readonly attribute float deviceVersion;
+          readonly attribute unsigned short deviceVersion;
           readonly attribute DOMString? manufacturer;
           readonly attribute DOMString? product;
           readonly attribute DOMString? serialNumber;
@@ -163,8 +163,10 @@
       </pre>
       <p dfn-for="USBDevice">
         The <code><dfn>usbVersion</dfn></code> attribute declares the USB
-        protocol version supported by the device. It SHALL correspond to the
-        value of the <code>bcdUSB</code> field of the device descriptor.
+        protocol version supported by the device as a
+        <a>Binary Coded Decimal</a> value with 2 digits past the decimal point.
+        It SHALL correspond to the value of the <code>bcdUSB</code> field of the
+        device descriptor.
       </p>
       <p dfn-for="USBDevice">
         The <code><dfn>deviceClass</dfn></code>,
@@ -185,9 +187,10 @@
       </p>
       <p dfn-for="USBDevice">
         The <code><dfn>deviceVersion</dfn></code> attribute declares the
-        device release number as defined by the device manufacturer. It SHALL
-        correspond to the value of the <code>bcdDevice</code> field of the
-        device descriptor.
+        device release number as defined by the device manufacturer as a
+        <a>Binary Coded Decimal</a> value with 2 digits past the decimal point.
+        It SHALL correspond to the value of the <code>bcdDevice</code> field of
+        the device descriptor.
       </p>
       <p dfn-for="USBDevice">
         The <code><dfn>configurations</dfn></code> attribute contains a list of
@@ -572,6 +575,17 @@
           Document <code>transferIn</code> and <code>transferOut</code>.
         </p>
       </section>
+    </section>
+    <section>
+      <h2>Definitions</h2>
+      <p>
+        A <dfn>Binary Coded Decimal</dfn> value is a fixed precision number
+        encoded using 4 bits per decimal digit (thus only hexadecimal values
+        <code>0</code> through <code>9</code> are valid) with a fixed decimal
+        point. These are often used for version numbers in the USB
+        specification. For example, <code>3.1</code> would be encoded as
+        <code>0x0310</code>.
+      </p>
     </section>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -145,13 +145,13 @@
       <pre class="idl">
         [NoInterfaceObject]
         interface USBDevice {
-          readonly attribute unsigned short usbVersion;
+          readonly attribute DOMString usbVersion;
           readonly attribute octet deviceClass;
           readonly attribute octet deviceSubclass;
           readonly attribute octet deviceProtocol;
           readonly attribute unsigned short vendorId;
           readonly attribute unsigned short productId;
-          readonly attribute unsigned short deviceVersion;
+          readonly attribute DOMString deviceVersion;
           readonly attribute DOMString? manufacturer;
           readonly attribute DOMString? product;
           readonly attribute DOMString? serialNumber;
@@ -162,11 +162,13 @@
         };
       </pre>
       <p dfn-for="USBDevice">
-        The <code><dfn>usbVersion</dfn></code> attribute declares the USB
-        protocol version supported by the device as a
-        <a>Binary Coded Decimal</a> value with 2 digits past the decimal point.
-        It SHALL correspond to the value of the <code>bcdUSB</code> field of the
-        device descriptor.
+        The <code><dfn>usbVersion</dfn></code> and
+        <code><dfn>deviceVersion</dfn></code> attributes declare the USB
+        protocol version supported by the device and device version assigned by
+        the manufacturer. They SHALL correspond respectively to the values of
+        the <code>bcdUSB</code> and <code>bcdDevice</code> fields of the device
+        descriptor. The values MUST be normalized such that there are two digits
+        to either side of the decimal point (for example, <code>"03.10"</code>).
       </p>
       <p dfn-for="USBDevice">
         The <code><dfn>deviceClass</dfn></code>,
@@ -184,13 +186,6 @@
         manufacturer. They SHALL correspond to the values of the
         <code>idVendor</code> and <code>idProduct</code> fields of the device
         descriptor.
-      </p>
-      <p dfn-for="USBDevice">
-        The <code><dfn>deviceVersion</dfn></code> attribute declares the
-        device release number as defined by the device manufacturer as a
-        <a>Binary Coded Decimal</a> value with 2 digits past the decimal point.
-        It SHALL correspond to the value of the <code>bcdDevice</code> field of
-        the device descriptor.
       </p>
       <p dfn-for="USBDevice">
         The <code><dfn>configurations</dfn></code> attribute contains a list of
@@ -575,17 +570,6 @@
           Document <code>transferIn</code> and <code>transferOut</code>.
         </p>
       </section>
-    </section>
-    <section>
-      <h2>Definitions</h2>
-      <p>
-        A <dfn>Binary Coded Decimal</dfn> value is a fixed precision number
-        encoded using 4 bits per decimal digit (thus only hexadecimal values
-        <code>0</code> through <code>9</code> are valid) with a fixed decimal
-        point. These are often used for version numbers in the USB
-        specification. For example, <code>3.1</code> would be encoded as
-        <code>0x0310</code>.
-      </p>
     </section>
   </body>
 </html>


### PR DESCRIPTION
To avoid percision issues with floats and yet retain the comparability
of these failues use the USB standard's binary coded decimal format for
the bcdUSB and bcdDevice fields exposed to through WebIDL.

This should resolve issue #8.