### PR TITLE
Some changes to bring IDL up to speed

### DIFF
--- a/index.html
+++ b/index.html
@@ -227,7 +227,7 @@
           readonly attribute octet deviceVersionMinor;
           readonly attribute octet deviceVersionSubminor;
           readonly attribute DOMString? manufacturer;
-          readonly attribute DOMString? product;
+          readonly attribute DOMString? productName;
           readonly attribute DOMString? serialNumber;
           readonly attribute FrozenArray&lt;USBConfiguration> configurations;
           Promise&lt;void> open();

--- a/index.html
+++ b/index.html
@@ -327,7 +327,7 @@
         [Constructor(USBDevice device, octet configurationValue)]
         interface USBConfiguration {
           readonly attribute octet configurationValue;
-          readonly attribute DOMString? configuration;
+          readonly attribute DOMString? configurationName;
           readonly attribute FrozenArray&lt;USBInterface> interfaces;
           Promise&lt;void> select();
         };
@@ -380,7 +380,7 @@
           readonly attribute octet interfaceClass;
           readonly attribute octet interfaceSubclass;
           readonly attribute octet interfaceProtocol;
-          readonly attribute DOMString? interface;
+          readonly attribute DOMString? interfaceName;
           readonly attribute FrozenArray&lt;USBEndpoint> endpoints;
           Promise&lt;void> select();
         };

--- a/index.html
+++ b/index.html
@@ -649,20 +649,6 @@
         </p>
       </section>
 
-      <section>
-        <h3>Isochronous Transfers</h3>
-        <pre class="idl">
-          interface USBIsochronousEndpoint : USBEndpoint {
-            Promise&lt;sequence&lt;ArrayBuffer>> transferIn(sequence&lt;unsigned long> packetLengths);
-            Promise&lt;sequence&lt;unsigned long>> transferOut(sequence&lt;BufferSource> packets);
-          };
-        </pre>
-        <p class="issue">
-          Document <code>transferIn</code> and <code>transferOut</code>.
-        </p>
-      </section>
-    </section>
-
     <section>
       <h2>Terminology</h2>
       <p>

--- a/index.html
+++ b/index.html
@@ -213,25 +213,19 @@
     <section>
       <h2>Device Usage</h2>
       <pre class="idl">
-        [Constructor(octet major, octet minor, octet subminor)]
-        interface USBVersionNumber {
-          readonly attribute octet major;
-          readonly attribute octet minor;
-          readonly attribute octet subminor;
-
-          bool isOlderThan(USBVersionNumber other);
-          bool equals(USBVersionNumber other);
-        };
-
         interface USBDevice {
           readonly attribute DOMString guid;
-          readonly attribute USBVersionNumber usbVersion;
+          readonly attribute octet usbVersionMajor;
+          readonly attribute octet usbVersionMinor;
+          readonly attribute octet usbVersionSubminor;
           readonly attribute octet deviceClass;
           readonly attribute octet deviceSubclass;
           readonly attribute octet deviceProtocol;
           readonly attribute unsigned short vendorId;
           readonly attribute unsigned short productId;
-          readonly attribute USBVersionNumber deviceVersion;
+          readonly attribute octet deviceVersionMajor;
+          readonly attribute octet deviceVersionMinor;
+          readonly attribute octet deviceVersionSubminor;
           readonly attribute DOMString? manufacturer;
           readonly attribute DOMString? product;
           readonly attribute DOMString? serialNumber;


### PR DESCRIPTION
Based on recent discussions:
  - Version changes are a compromise between a combined format and a separate version interface
  - foo -> fooName for consistency (plus "interface" is not a valid identifier).
  - Scrapped the isochronous endpoint interface. iso endpoints still visible, but support only control xfer